### PR TITLE
Add linker ability to load precompiled libraries

### DIFF
--- a/doc/refman/tex/toolchain/usage.tex
+++ b/doc/refman/tex/toolchain/usage.tex
@@ -32,6 +32,7 @@ label".
         -h --help           Print this help.
         -o <file>           Output LDM file name. If not specified,
                             name of first object file will be used.
+        -l <path>           Path to look for libraries.
            --version        Print version number and exit.
 \end{lstlisting}
 
@@ -44,6 +45,12 @@ In that case just compile each file separated and then call:
 \begin{lstlisting}[language=bash, frame=single]
     # linker file1.o file2.o
 \end{lstlisting}
+
+Linker is also needed when one want use compiled libraries. These 
+libraries are classical object files without any modifications. Linker 
+first try to link your ldm file from object files given as argument, 
+when some missing labels are occurred, patch given with -l argument are 
+searched for object files. 
 
 \subsubsection{ldm2mif}
 

--- a/toolchain/m2tools/src/linker/linker.py
+++ b/toolchain/m2tools/src/linker/linker.py
@@ -287,7 +287,7 @@ class object_buffer():
                 name = label_item.name
                 found, value = self.__find_exported_label(name)
 
-                if found == "False":
+                if found == False:
                     print "Label '" +  name + "' is not exported! Can not link files! Exiting!"
                     sys.exit(1)
 

--- a/toolchain/m2tools/src/linker/linker.py
+++ b/toolchain/m2tools/src/linker/linker.py
@@ -357,6 +357,7 @@ class object_buffer():
                 sys.exit()
             else:
                 self.files.append(lib)
+                break
         
         self.missing_exports = []
         


### PR DESCRIPTION
This pull request add new option `-l <path>` to the linker. This option cause linker will search specified directory for others object files and try use them to resolve missing labels.

### TODO:

- [x] Edit linker source
- [x] Add informations about this feature into refman 
- [x] Test updated linker